### PR TITLE
Revert Scroll Indicator change

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -9,50 +9,45 @@
     <link rel="shortcut icon" type="image/ico" href="~/favicon.ico">
 </head>
 <body>
-    <div class="header">
-        <div class="progress-container">
-            <header>
-                <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-#7952b3 border-bottom box-shadow bd-navbar">
-                    <div class="container">
-                        <a style="font-family: Inter, sans-serif; font-size: 1em; line-height: 1.5em; font-weight: 700; letter-spacing: 0.013em;" class="Gradient" asp-area="" asp-page="/Index">Callum's Website</a>
-                        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                                aria-expanded="false" aria-label="Toggle navigation">
-                            <span class="navbar-toggler-icon"></span>
-                        </button>
-                        <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                            <ul class="navbar-nav flex-grow-1">
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-#7952b3 border-bottom box-shadow mb-3 bd-navbar">
+            <div class="container">
+                <a style="font-family: Inter, sans-serif; font-size: 1em; line-height: 1.5em; font-weight: 700; letter-spacing: 0.013em;" class="Gradient" asp-area="" asp-page="/Index">Callum's Website</a>
+                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                        aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                    <ul class="navbar-nav flex-grow-1">
 
-                                <li class="nav-item">
-                                    <a class="nav-link text-light" asp-area="" asp-page="/AboutMe">About Me</a>
-                                </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-light" asp-area="" asp-page="/AboutMe">About Me</a>
+                        </li>
 
-                                <li class="nav-item">
-                                    <a class="nav-link text-light" asp-area="" asp-page="/Privacy">Privacy</a>
-                                </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-light" asp-area="" asp-page="/Privacy">Privacy</a>
+                        </li>
 
-                                <li class="nav-item">
-                                    <a class="nav-link text-light" asp-area="" asp-page="/Pictures">Pictures</a>
-                                </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-light" asp-area="" asp-page="/Pictures">Pictures</a>
+                        </li>
 
-                                <li class="nav-item">
-                                    <a class="nav-link text-light" asp-area="" asp-page="/Documents">Documents</a>
-                                </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-light" asp-area="" asp-page="/Documents">Documents</a>
+                        </li>
 
-                                <li class="nav-item">
-                                    <a class="nav-link text-light" asp-area="" asp-page="/Test">Test</a>
-                                </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-light" asp-area="" asp-page="/Test">Test</a>
+                        </li>
 
-                                <li class="nav-item">
-                                    <a class="nav-link text-light" asp-area="" asp-page="/What'sNew">What's new</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </nav>
-            </header>
-            <div class="progress-bar" id="myBar"></div>
-        </div>
-    </div>
+                        <li class="nav-item">
+                            <a class="nav-link text-light" asp-area="" asp-page="/What'sNew">What's new</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
     <div class="container">
         <main role="main" class="pb-3">
             <div class="textStyleCSS">
@@ -74,17 +69,6 @@
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
-    <script>
-        // When the user scrolls the page, execute myFunction
-        window.onscroll = function () { myFunction() };
-
-        function myFunction() {
-            var winScroll = document.body.scrollTop || document.documentElement.scrollTop;
-            var height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-            var scrolled = (winScroll / height) * 100;
-            document.getElementById("myBar").style.width = scrolled + "%";
-        }
-    </script>
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -68,6 +68,10 @@ html {
     border-top: 0.0625em solid #e5e5e5; /* Was 1px */
 }
 
+.border-bottom {
+    border-bottom: 0.0625em solid #e5e5e5; /* Was 1px */
+}
+
 .box-shadow {
     box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
@@ -342,28 +346,3 @@ div.responsiveText {
 .iconsSpace {
     margin-right: 8px;
 }
-
-/* --- Scroll indicator --- */
-/* Style the header: fixed position (always stay at the top) */
-.header {
-    position: fixed;
-    top: 0;
-    z-index: 1;
-    width: 100%;
-    background-color: #f1f1f1;
-}
-
-/* The progress container (grey background) */
-.progress-container {
-    width: 100%;
-    height: 8px;
-    background: #ccc;
-}
-
-/* The progress bar (scroll indicator) */
-.progress-bar {
-    height: 8px;
-    background: #9e68ed;
-    width: 0%;
-}
-/* --- Scroll indicator --- */

--- a/wwwroot/lib/bootstrap/dist/css/bootstrap.min.css
+++ b/wwwroot/lib/bootstrap/dist/css/bootstrap.min.css
@@ -6512,6 +6512,10 @@ pre {
         border-right: 1px solid #dee2e6 !important
     }
 
+    .border-bottom {
+        border-bottom: 1px solid #dee2e6 !important
+    }
+
     .border-left {
         border-left: 1px solid #dee2e6 !important
     }


### PR DESCRIPTION
-Revert back to commit 4a49ec38570cdba38dbd21c2a0156dd6afb95082 (Update site.css)
-Reason being that the implementation of the scroll indicator was buggy and caused a large part of the top of the page from being rendered. I tried a number of options but the scroll indicator kept being the issue when altering variables.